### PR TITLE
Option to run in gui mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.pyc
+/.idea/
+/.pytest_cache/
 /bin/
 /build/
 /dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - linux
   - osx
 osx_image: xcode9.1
-install: 
+install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         MINICONDA_VERSION=2 ;
     else

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+!/bin/bash
 
 sudo apt-get update
 
@@ -44,10 +44,8 @@ Fiji.app/$launcher --update update-force-pristine
 # -- install imglyb --
 conda install -c hanslovsky imglyb
 
-# -- clone testing unit --
-git clone git://github.com/imagej/imagej.py
-cd imagej.py
-git checkout pyjnius
+# -- run the Python code --
+cd $TRAVIS_BUILD_DIR
 
 # -- set ij dirctory --
 ij_dir=$HOME/Fiji.app

--- a/imagej/imagej.py
+++ b/imagej/imagej.py
@@ -8,6 +8,7 @@ __author__ = 'Yang Liu & Curtis Rueden'
 
 import os
 import jnius_config
+from pathlib import Path
 
 
 def _debug(message):
@@ -66,6 +67,9 @@ def init(ij_dir, headless=True):
     
     if headless:
         jnius_config.add_options('-Djava.awt.headless=true')
+    
+    plugins_dir = str(Path(ij_dir, 'plugins'))
+    jnius_config.add_options('-Dplugins.dir=' + plugins_dir)
     
     num_jars = set_ij_env(ij_dir)
     print("Added " + str(num_jars + 1) + " JARs to the Java classpath.")

--- a/imagej/imagej.py
+++ b/imagej/imagej.py
@@ -56,15 +56,17 @@ def set_ij_env(ij_dir):
     return num_jars
 
 
-def init(ij_dir):
+def init(ij_dir, headless=True):
     """
     quietly set up the whole environment
 
     :param ij_dir: System path for Fiji.app
     :return: an instance of the net.imagej.ImageJ gateway
     """
-
-    jnius_config.add_options('-Djava.awt.headless=true')
+    
+    if headless:
+        jnius_config.add_options('-Djava.awt.headless=true')
+    
     num_jars = set_ij_env(ij_dir)
     print("Added " + str(num_jars + 1) + " JARs to the Java classpath.")
     import imglyb

--- a/imagej/imagej.py
+++ b/imagej/imagej.py
@@ -64,16 +64,16 @@ def init(ij_dir, headless=True):
     :param ij_dir: System path for Fiji.app
     :return: an instance of the net.imagej.ImageJ gateway
     """
-    
+
     if headless:
         jnius_config.add_options('-Djava.awt.headless=true')
-    
+
     plugins_dir = str(Path(ij_dir, 'plugins'))
     jnius_config.add_options('-Dplugins.dir=' + plugins_dir)
-    
+
     num_jars = set_ij_env(ij_dir)
     print("Added " + str(num_jars + 1) + " JARs to the Java classpath.")
-    
+
     # It is necessary to import imglyb before jnius because it sets options for the JVM and jnius starts up the JVM
     import imglyb
     from jnius import autoclass
@@ -88,6 +88,6 @@ def help():
     :return:
     """
 
-    print(("Please set the environment variables first:\n" 
+    print(("Please set the environment variables first:\n"
            "Fiji.app:   ij_dir = 'your local fiji.app path'\n"
            "Then call init(ij_dir)"))

--- a/imagej/imagej.py
+++ b/imagej/imagej.py
@@ -73,6 +73,8 @@ def init(ij_dir, headless=True):
     
     num_jars = set_ij_env(ij_dir)
     print("Added " + str(num_jars + 1) + " JARs to the Java classpath.")
+    
+    # It is necessary to import imglyb before jnius because it sets options for the JVM and jnius starts up the JVM
     import imglyb
     from jnius import autoclass
     ImageJ = autoclass('net.imagej.ImageJ')

--- a/imagej/server/README.md
+++ b/imagej/server/README.md
@@ -14,7 +14,7 @@ Use `pip install -r requirements.txt` to install requirements.
 ## Usage:
 
 Try running [usage.py](usage.py) in the directory of this README file and see the results.
- 
+
 ```Python
 # This script shows the basic functionalities of the Python imagej client.
 # It uploads an image to imagej-server, inverts the image, and display both the
@@ -58,73 +58,73 @@ The entry point of imagej.py is an *__IJ__* object, which has the following func
 ```
 class imagej.IJ(host='http://localhost:8080')
     Creates a client that bounds to host.
-       
+
     :param host: address of imagej-server
-   
+
 IJ.detail(id)
     Gets the detail of a module or an object specified by the ID.
 
     :param id: the ID of a module or an object
     :return: details of a module or an object
     :rtype: dict
-   
+
 IJ.find(regex)
     Finds all module IDs that match the regular expression.
-       
+
     :param regex: the regular express to match the module IDs
     :return: all matching IDs
     :rtype: list[string]
-   
+
 IJ.modules(refresh=False)
     Gets the module IDs of imagej-server if no cache is available or
     refresh is set to True, or returns the cache for the IDs otherwise.
-       
+
     :param refresh: force fetching modules from imagej-server if True
     :return: imagej-server module IDs
     :rtype: list[string]
-   
+
 IJ.objects()
     Gets a list of objects being served on imagej-server, sorted by ID.
-       
+
     :return: a list of object IDs
     :rtype: list[string]
-    
+
 IJ.remove(id)
     Removes one object from imagej-server.
-        
+
     :param id: object ID to remove
-   
+
 IJ.retrieve(id, format, config=None, dest=None)
     Retrieves an object in specific format from imagej-server.
-       
+
     If dest is None, the raw content would be returned.
-       
+
     :param id: object ID
     :param format: file format the object to be saved into
     :param config: configuration for storing the object (not tested)
     :param dest: download destination
     :return: content of the object if dest is None, otherwise None
     :rtype: string or None
-   
+
 IJ.run(id, inputs=None, process=True)
     Runs a module specified by the ID with inputs.
-       
+
     :param id: the ID of the module
     :param inputs: a dict-like object containing inputs for the execution
     :param process: if the execution should be pre/post processed
     :return: outputs of the execution
     :rtype: dict
-   
+
 IJ.show(id, format, config=None)
     Retrieves and shows an object in specific format from imagej-server.
-       
+
     :param id: object ID if format is set, or a file being served
     :param format: file format the object to be saved into
     :param config: configuration for storing the object (not tested)
-   
+
 IJ.upload(filename)
     Uploads a file to imagej-server
-       
+
     :param filename: filename of the file to be uploaded
     :param type: optional hint for file type
     :return: object ID of the uploaded file

--- a/test/test_imagej.py
+++ b/test/test_imagej.py
@@ -82,6 +82,22 @@ class TestImageJ(unittest.TestCase):
             result.append(itr.next().get())
         self.assertEqual(result, correct_result)
 
+    def testPluginsLoadUsingPairwiseStitching(self):
+        macro = """
+        
+        newImage("Tile1", "8-bit random", 512, 512, 1);
+        newImage("Tile2", "8-bit random", 512, 512, 1);
+        run("Pairwise stitching", "first_image=Tile1 second_image=Tile2");"""
+        
+        ij.script().run('macro.ijm', macro, True).get()
+        WindowManager = autoclass('ij.WindowManager')
+        result_name = WindowManager.getCurrentImage().getTitle()
+        
+        ij.script().run('macro.ijm', 'run("Close All");', True).get()
+        
+        self.assertEqual(result_name, 'Tile1<->Tile2')
+        
+
     def main(self):
         unittest.main()
 

--- a/test/test_imagej.py
+++ b/test/test_imagej.py
@@ -43,7 +43,7 @@ class TestImageJ(unittest.TestCase):
                 ra.setPosition(x, y)
                 result.append(ra.get().get())
         self.assertEqual(result, correct_result)
-    
+
     """
     def testTopHat(self):
         ArrayList = autoclass('java.util.ArrayList')
@@ -84,19 +84,19 @@ class TestImageJ(unittest.TestCase):
 
     def testPluginsLoadUsingPairwiseStitching(self):
         macro = """
-        
+
         newImage("Tile1", "8-bit random", 512, 512, 1);
         newImage("Tile2", "8-bit random", 512, 512, 1);
         run("Pairwise stitching", "first_image=Tile1 second_image=Tile2");"""
-        
+
         ij.script().run('macro.ijm', macro, True).get()
         WindowManager = autoclass('ij.WindowManager')
         result_name = WindowManager.getCurrentImage().getTitle()
-        
+
         ij.script().run('macro.ijm', 'run("Close All");', True).get()
-        
+
         self.assertEqual(result_name, 'Tile1<->Tile2')
-        
+
 
     def main(self):
         unittest.main()


### PR DESCRIPTION
This commit makes two changes to ImageJ.py

# GUI mode
it possible to turn off headless mode by setting calling imagej.init() as such 

```
ij = imagej.init(ij_dir, headless=False)
```

There is also a new test file, named test_imagej_headless_false, which is a copy of test_imagej setup with headless=False.  This new test file is necessary because the JVM can only be set up once per process, and so the test needs to be run on a separate module/process.

Travis CI does not call this new test file, as Travis runs in headless mode by default and it causes conflicts with OSX.  However, it can be called/updated manually and should achieve the same results as test_imagej.py.

# Load Fiji Plugins for scripting
Prior to this commit, IJ would not load plugins.  The plugins were loaded into the Java classpath, but they were not loaded into IJ's scripting environment.  This change adds the Fiji plugins directory into IJ's load path manually.

In addition, a test is implemented using the plugin PairwiseStitching to ensure that the plugins are loading properly.